### PR TITLE
Create add book flow for frontend

### DIFF
--- a/frontend/src/components/AddBookDialog.tsx
+++ b/frontend/src/components/AddBookDialog.tsx
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -8,14 +9,17 @@ import {
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
-import { Textarea } from './ui/textarea';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from './ui/select';
+import { toast } from 'react-hot-toast';
+
+// some of these fields are strangely named, but they match the JSON response from Open Library
+interface OpenLibraryBook {
+  key: string;
+  title: string;
+  edition_key?: string;
+  author_name?: string[];
+  cover_i?: number;
+  cover_edition_key?: string;
+}
 
 interface AddBookDialogProps {
   open: boolean;
@@ -23,63 +27,189 @@ interface AddBookDialogProps {
 }
 
 export function AddBookDialog({ open, onOpenChange }: AddBookDialogProps) {
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
+  const [title, setTitle] = useState('');
+  const [author, setAuthor] = useState('');
+  const [editions, setEditions] = useState<OpenLibraryBook[]>([]);
+  const [pageIndex, setPageIndex] = useState(0);
+  const [selectedEditionKey, setSelectedEditionKey] = useState<string | null>(null);
+  const [selectedPageCount, setSelectedPageCount] = useState<number | null>(null);
+  const [manualPagesDialogOpen, setManualPagesDialogOpen] = useState(false);
+  const [manualPageCount, setManualPageCount] = useState<number | null>(null);
+
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  const submitBook = async () => {
+    const pageCount = selectedPageCount ?? manualPageCount;
+    // TODO - submit the book to backend
+    toast.success(`Book added! (Pages: ${pageCount ?? 'N/A'})`);
     onOpenChange(false);
+  }
+
+  const handleAddBook = () => {
+    if (!selectedPageCount) {
+      setManualPagesDialogOpen(true);
+    } else {
+      submitBook();
+    }
   };
 
+
+  const handleSearch = async () => {
+    if (!title && !author) return;
+    const params = new URLSearchParams();
+    if (title) params.append('title', title);
+    if (author) params.append('author', author);
+    params.append('limit', '50');
+
+    const res = await fetch(`https://openlibrary.org/search.json?${params.toString()}`);
+    const data = await res.json();
+    setEditions(data.docs);
+    setPageIndex(0);
+  };
+
+  const changePage = (delta: number) => {
+    setSelectedEditionKey(null);
+    setSelectedPageCount(null);
+    setPageIndex((i) => {
+      const next = i + delta;
+      return Math.max(0, Math.min(next, Math.floor(editions.length / 5)));
+    });
+    if (scrollRef.current) scrollRef.current.scrollTop = 0;
+  };
+
+  const currentPage = editions.slice(pageIndex * 5, pageIndex * 5 + 5);
+
+  useEffect(() => {
+    if (!selectedEditionKey) {
+      setSelectedPageCount(null);
+      return;
+    }
+
+    const fetchEditionDetails = async () => {
+      // this check is to ensure we only fetch for valid edition keys. Some keys
+      // in Open Library are "work" keys which don't have page count info
+      if (selectedEditionKey.startsWith('OL') && selectedEditionKey.endsWith('M')) {
+        try {
+          const res = await fetch(`https://openlibrary.org/books/${selectedEditionKey}.json`);
+          const data = await res.json();
+          const pages = data.number_of_pages ?? null;
+          setSelectedPageCount(pages);
+        } catch (err) {
+          console.error('Failed to fetch edition details:', err);
+          setSelectedPageCount(null);
+        }
+      }
+    };
+
+    fetchEditionDetails();
+  }, [selectedEditionKey]);
+
+
   return (
+    <>
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Add New Book</DialogTitle>
           <DialogDescription>
-            Add a book to your reading collection. You can update the details later.
+            Add a book to your reading collection.
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-5 mt-4">
+        <form onSubmit={handleAddBook} className="space-y-5 mt-4">
           <div className="space-y-2">
-            <Label htmlFor="book-title">Book Title</Label>
+            <Label htmlFor="book-title">Title</Label>
             <Input
               id="book-title"
               placeholder="Enter book title"
               className="bg-gray-50"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
             />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="author">Author</Label>
-            <Input
-              id="author"
-              placeholder="Enter author name"
-              className="bg-gray-50"
-            />
+            <div className="flex gap-2">
+              <Input
+                id="author"
+                placeholder="Enter author name"
+                className="bg-gray-50 flex-1"
+                value={author}
+                onChange={(e) => setAuthor(e.target.value)}
+              />
+              <Button
+                type="button"
+                variant="outline"
+                disabled={!title.trim() && !author.trim()}
+                onClick={handleSearch}
+              >
+                Search Books
+              </Button>
+            </div>
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="status">Reading Status</Label>
-            <Select defaultValue="wishlist">
-              <SelectTrigger id="status" className="bg-gray-50">
-                <SelectValue placeholder="Select status" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="wishlist">Wishlist</SelectItem>
-                <SelectItem value="reading">Currently Reading</SelectItem>
-                <SelectItem value="read">Read</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
+          {editions.length > 0 && (
+            <div ref={scrollRef} className="border rounded p-2 h-65 overflow-y-auto">
+              {currentPage.map((edition) => {
+                const editionId = edition.cover_edition_key ?? edition.edition_key?.[0] ?? edition.key;
 
-          <div className="space-y-2">
-            <Label htmlFor="notes">Notes (optional)</Label>
-            <Textarea
-              id="notes"
-              placeholder="Add any notes or thoughts about this book"
-              className="bg-gray-50 resize-none"
-              rows={3}
-            />
-          </div>
+                return (
+                  <div
+                    key={edition.key}
+                    className={`flex flex-col gap-1 mb-3 p-2 rounded cursor-pointer 
+                      ${selectedEditionKey === editionId ? 'border-2 border-blue-600 bg-blue-50' : 'border border-transparent'}
+                    `}
+                    onClick={() => {
+                      setSelectedPageCount(null);
+                      setSelectedEditionKey(editionId);
+                    }}
+                  >
+                    <div className="flex items-center gap-3">
+                      {edition.cover_i ? (
+                        <img
+                          src={`https://covers.openlibrary.org/b/id/${edition.cover_i}-M.jpg`}
+                          alt={edition.title}
+                          className="w-12 h-16 object-cover rounded"
+                        />
+                      ) : (
+                        <div className="w-12 h-16 bg-gray-200 flex items-center justify-center text-xs rounded">
+                          No Cover
+                        </div>
+                      )}
+                      <div>
+                        <div className="font-medium">{edition.title}</div>
+                        <div className="text-sm text-gray-500">{edition.author_name?.join(', ')}</div>
+                      </div>
+                    </div>
+
+                    {selectedEditionKey === editionId && selectedPageCount !== null && (
+                      <div className="text-xs text-gray-400">Pages: {selectedPageCount}</div>
+                    )}
+                  </div>
+                );
+              })}
+
+              <div className="flex justify-between mt-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => changePage(-1)}
+                  disabled={pageIndex === 0}
+                >
+                  Previous
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => changePage(1)}
+                  disabled={pageIndex >= Math.floor(editions.length / 5)}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
 
           <div className="flex gap-3 pt-4">
             <Button
@@ -91,8 +221,10 @@ export function AddBookDialog({ open, onOpenChange }: AddBookDialogProps) {
               Cancel
             </Button>
             <Button
-              type="submit"
+              type="button"
               className="flex-1 bg-linear-to-r from-blue-600 to-green-600 hover:from-blue-700 hover:to-green-700"
+              disabled={!selectedEditionKey}
+              onClick={() => handleAddBook()}
             >
               Add Book
             </Button>
@@ -100,5 +232,52 @@ export function AddBookDialog({ open, onOpenChange }: AddBookDialogProps) {
         </form>
       </DialogContent>
     </Dialog>
+
+    <Dialog open={manualPagesDialogOpen} onOpenChange={setManualPagesDialogOpen}>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>Enter Page Count</DialogTitle>
+          <DialogDescription>
+            Please enter the page count for this book.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 mt-4">
+          <Input
+            type="number"
+            min={1}
+            placeholder="Number of pages"
+            value={manualPageCount ?? ''}
+            onChange={(e) => setManualPageCount(Number(e.target.value))}
+            className="bg-gray-50"
+          />
+
+          <div className="flex gap-3 pt-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => setManualPagesDialogOpen(false)}
+              className="flex-1"
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              disabled={!manualPageCount || manualPageCount <= 0}
+              className="flex-1 bg-linear-to-r from-blue-600 to-green-600 hover:from-blue-700 hover:to-green-700"
+              onClick={() => {
+                if (manualPageCount && manualPageCount > 0) {
+                  submitBook();
+                  setManualPagesDialogOpen(false);
+                }
+              }}
+            >
+              Submit
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
This PR adds a frontend process for searching for and adding books to a user's reading list. This process:
- Uses the [Open Library Search API](https://openlibrary.org/dev/docs/api/search) to allow users to search for a book to add by title and/or author.
- Displays resulting books from the search in pages of 5 books at a time.
- Allows a user to select a book from the list to add as their book they are reading.
- Once a book is selected, we try requesting its page count from the Open Library Search API. Page count information is only accessible via requesting a book's specific edition_key. Some books do not have an edition_key and exist only as "works", and some books do have an edition_key but still don't have page count information tracked. In cases where there isn't an edition_key or page count information isn't tracked, it is on the user to add page count information.
- Right now, a toast message indicating successful addition appears in lieu of making a backend POST request to add the book.

Here's a screenshot of the state of the add book dialog after searching for "harry potter" and selecting one of the options. As you can see, we were able to successfully get the page count from the Open Library API in this instance, so the user won't have to add a page count manually.
<img width="1503" height="846" alt="Screenshot 2025-11-07 at 3 36 30 PM" src="https://github.com/user-attachments/assets/6727ae52-5114-40bb-85cf-ff5424dd4be9" />
