### PR TITLE
Feat/books api

### DIFF
--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1378,7 +1378,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+							"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 						},
 						"url": {
 							"raw": "{{base_url}}/api/books",
@@ -1405,7 +1405,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1428,7 +1428,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_key\": \"OL27482W\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
+							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_key\": \"OL51709286M\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
 						},
 						{
 							"name": "Create Book - Reading",
@@ -1553,7 +1553,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1590,7 +1590,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1616,6 +1616,110 @@
 							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
 						}
 					]
+				},
+				{
+					"name": "Get Books",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/api/books",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"books"
+							]
+						},
+						"description": "Get all books in the authenticated user's library. Returns title, author, status (wishlist/reading/read), open_library_id, page_progress, total_pages, and rating."
+					},
+					"response": [
+						{
+							"name": "Get Books Success",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[\n  {\n    \"title\": \"The Hobbit\",\n    \"author\": \"J.R.R. Tolkien\",\n    \"status\": \"wishlist\",\n    \"open_library_id\": \"OL51709286M\",\n    \"page_progress\": 0,\n    \"total_pages\": 310,\n    \"rating\": null\n  },\n  {\n    \"title\": \"1984\",\n    \"author\": \"George Orwell\",\n    \"status\": \"reading\",\n    \"open_library_id\": \"OL1168007W\",\n    \"page_progress\": 150,\n    \"total_pages\": 328,\n    \"rating\": null\n  },\n  {\n    \"title\": \"To Kill a Mockingbird\",\n    \"author\": \"Harper Lee\",\n    \"status\": \"read\",\n    \"open_library_id\": \"OL26965W\",\n    \"page_progress\": 281,\n    \"total_pages\": 281,\n    \"rating\": 5\n  }\n]"
+						},
+						{
+							"name": "Get Books - Empty Library",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "[]"
+						},
+						{
+							"name": "Get Books - Unauthorized",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
+						}
+					]
 				}
 			],
 			"description": "Endpoints for managing books in user's library",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1378,7 +1378,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
+							"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_id\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 						},
 						"url": {
 							"raw": "{{base_url}}/api/books",
@@ -1405,7 +1405,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_id\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1428,7 +1428,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_key\": \"OL51709286M\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
+							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_id\": \"OL51709286M\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
 						},
 						{
 							"name": "Create Book - Reading",
@@ -1442,7 +1442,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"page_progress\": 150,\n  \"open_library_key\": \"OL1168007W\",\n  \"total_pages\": 328\n}"
+									"raw": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"page_progress\": 150,\n  \"open_library_id\": \"OL1168007W\",\n  \"total_pages\": 328\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1465,7 +1465,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_key\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328\n}"
+							"body": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_id\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328\n}"
 						},
 						{
 							"name": "Create Book - Finished",
@@ -1479,7 +1479,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"page_progress\": 281,\n  \"open_library_key\": \"OL26965W\",\n  \"total_pages\": 281\n}"
+									"raw": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"page_progress\": 281,\n  \"open_library_id\": \"OL26965W\",\n  \"total_pages\": 281\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1502,7 +1502,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_key\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281\n}"
+							"body": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_id\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281\n}"
 						},
 						{
 							"name": "Create Book - Missing Title",
@@ -1516,7 +1516,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"author\": \"J.K. Rowling\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL82563W\"\n}"
+									"raw": "{\n  \"author\": \"J.K. Rowling\",\n  \"page_progress\": 0,\n  \"open_library_id\": \"OL82563W\"\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1553,7 +1553,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_id\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",
@@ -1590,7 +1590,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_id\": \"OL51709286M\",\n  \"total_pages\": 310\n}"
 								},
 								"url": {
 									"raw": "{{base_url}}/api/books",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1835,6 +1835,239 @@
 							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
 						}
 					]
+				},
+				{
+					"name": "Update Book Progress",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"page_progress\": 150\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/books/:book_id/progress",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"books",
+								":book_id",
+								"progress"
+							],
+							"variable": [
+								{
+									"key": "book_id",
+									"value": "1",
+									"description": "The ID of the book to update"
+								}
+							]
+						},
+						"description": "Update the reading progress (page number) for a book in the user's library. Returns all book details with updated status."
+					},
+					"response": [
+						{
+							"name": "Update Book Progress Success",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"page_progress\": 150\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/2/progress",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"2",
+										"progress"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": 2,\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_id\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328,\n  \"rating\": null\n}"
+						},
+						{
+							"name": "Update Book Progress - Completed",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"page_progress\": 328\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/2/progress",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"2",
+										"progress"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": 2,\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"read\",\n  \"open_library_id\": \"OL1168007W\",\n  \"page_progress\": 328,\n  \"total_pages\": 328,\n  \"rating\": null\n}"
+						},
+						{
+							"name": "Update Book Progress - Not Found",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"page_progress\": 150\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/999/progress",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"999",
+										"progress"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Book not found in your library\"\n}"
+						},
+						{
+							"name": "Update Book Progress - Missing Progress",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/2/progress",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"2",
+										"progress"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Page progress is required\"\n}"
+						},
+						{
+							"name": "Update Book Progress - Unauthorized",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"page_progress\": 150\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/2/progress",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"2",
+										"progress"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
+						}
+					]
 				}
 			],
 			"description": "Endpoints for managing books in user's library",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -74,9 +74,9 @@
 									"if (pm.response.code === 201) {",
 									"    const responseJson = pm.response.json();",
 									"    if (responseJson.token) {",
-									"        pm.environment.set('auth_token', responseJson.token);",
-									"        pm.environment.set('user_id', responseJson.user.id);",
-									"        pm.environment.set('username', responseJson.user.username);",
+									"        pm.collectionVariables.set('auth_token', responseJson.token);",
+									"        pm.collectionVariables.set('user_id', responseJson.user.id);",
+									"        pm.collectionVariables.set('username', responseJson.user.username);",
 									"    }",
 									"}"
 								],

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1362,6 +1362,273 @@
 					}
 				]
 			}
+		},
+		{
+			"name": "Books",
+			"item": [
+				{
+					"name": "Create Book",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/books",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"books"
+							]
+						},
+						"description": "Add a new book to the authenticated user's library. Status is calculated based on page_progress: 0 pages = wishlist, 0 < progress < 100% = reading, 100% = read."
+					},
+					"response": [
+						{
+							"name": "Create Book Success",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_key\": \"OL27482W\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
+						},
+						{
+							"name": "Create Book - Reading",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"page_progress\": 150,\n  \"open_library_key\": \"OL1168007W\",\n  \"total_pages\": 328\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_key\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328\n}"
+						},
+						{
+							"name": "Create Book - Finished",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"page_progress\": 281,\n  \"open_library_key\": \"OL26965W\",\n  \"total_pages\": 281\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Created",
+							"code": 201,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_key\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281\n}"
+						},
+						{
+							"name": "Create Book - Missing Title",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"author\": \"J.K. Rowling\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL82563W\"\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Title is required\"\n}"
+						},
+						{
+							"name": "Create Book - Already Exists",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Book already in your library\"\n}"
+						},
+						{
+							"name": "Create Book - Unauthorized",
+							"originalRequest": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"page_progress\": 0,\n  \"open_library_key\": \"OL27482W\",\n  \"total_pages\": 310\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
+						}
+					]
+				}
+			],
+			"description": "Endpoints for managing books in user's library",
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "{{auth_token}}",
+						"type": "string"
+					}
+				]
+			}
 		}
 	],
 	"event": [

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1428,7 +1428,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_id\": \"OL51709286M\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
+							"body": "{\n  \"id\": 1,\n  \"title\": \"The Hobbit\",\n  \"author\": \"J.R.R. Tolkien\",\n  \"status\": \"wishlist\",\n  \"open_library_id\": \"OL51709286M\",\n  \"page_progress\": 0,\n  \"total_pages\": 310\n}"
 						},
 						{
 							"name": "Create Book - Reading",
@@ -1465,7 +1465,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_id\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328\n}"
+							"body": "{\n  \"id\": 2,\n  \"title\": \"1984\",\n  \"author\": \"George Orwell\",\n  \"status\": \"reading\",\n  \"open_library_id\": \"OL1168007W\",\n  \"page_progress\": 150,\n  \"total_pages\": 328\n}"
 						},
 						{
 							"name": "Create Book - Finished",
@@ -1502,7 +1502,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "{\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_id\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281\n}"
+							"body": "{\n  \"id\": 3,\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_id\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281\n}"
 						},
 						{
 							"name": "Create Book - Missing Title",
@@ -1661,7 +1661,7 @@
 								}
 							],
 							"cookie": [],
-							"body": "[\n  {\n    \"title\": \"The Hobbit\",\n    \"author\": \"J.R.R. Tolkien\",\n    \"status\": \"wishlist\",\n    \"open_library_id\": \"OL51709286M\",\n    \"page_progress\": 0,\n    \"total_pages\": 310,\n    \"rating\": null\n  },\n  {\n    \"title\": \"1984\",\n    \"author\": \"George Orwell\",\n    \"status\": \"reading\",\n    \"open_library_id\": \"OL1168007W\",\n    \"page_progress\": 150,\n    \"total_pages\": 328,\n    \"rating\": null\n  },\n  {\n    \"title\": \"To Kill a Mockingbird\",\n    \"author\": \"Harper Lee\",\n    \"status\": \"read\",\n    \"open_library_id\": \"OL26965W\",\n    \"page_progress\": 281,\n    \"total_pages\": 281,\n    \"rating\": 5\n  }\n]"
+							"body": "[\n  {\n    \"id\": 1,\n    \"title\": \"The Hobbit\",\n    \"author\": \"J.R.R. Tolkien\",\n    \"status\": \"wishlist\",\n    \"open_library_id\": \"OL51709286M\",\n    \"page_progress\": 0,\n    \"total_pages\": 310,\n    \"rating\": null\n  },\n  {\n    \"id\": 2,\n    \"title\": \"1984\",\n    \"author\": \"George Orwell\",\n    \"status\": \"reading\",\n    \"open_library_id\": \"OL1168007W\",\n    \"page_progress\": 150,\n    \"total_pages\": 328,\n    \"rating\": null\n  },\n  {\n    \"id\": 3,\n    \"title\": \"To Kill a Mockingbird\",\n    \"author\": \"Harper Lee\",\n    \"status\": \"read\",\n    \"open_library_id\": \"OL26965W\",\n    \"page_progress\": 281,\n    \"total_pages\": 281,\n    \"rating\": 5\n  }\n]"
 						},
 						{
 							"name": "Get Books - Empty Library",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -236,9 +236,9 @@
 									"if (pm.response.code === 200) {",
 									"    const responseJson = pm.response.json();",
 									"    if (responseJson.token) {",
-									"        pm.environment.set('auth_token', responseJson.token);",
-									"        pm.environment.set('user_id', responseJson.user.id);",
-									"        pm.environment.set('username', responseJson.user.username);",
+									"        pm.collectionVariables.set('auth_token', responseJson.token);",
+									"        pm.collectionVariables.set('user_id', responseJson.user.id);",
+									"        pm.collectionVariables.set('username', responseJson.user.username);",
 									"    }",
 									"}"
 								],

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -1720,6 +1720,121 @@
 							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
 						}
 					]
+				},
+				{
+					"name": "Delete Book",
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{base_url}}/api/books/:book_id",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"books",
+								":book_id"
+							],
+							"variable": [
+								{
+									"key": "book_id",
+									"value": "1",
+									"description": "The ID of the book to delete"
+								}
+							]
+						},
+						"description": "Remove a book from the authenticated user's library by book ID."
+					},
+					"response": [
+						{
+							"name": "Delete Book Success",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books/1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"message\": \"Book removed from library\"\n}"
+						},
+						{
+							"name": "Delete Book - Not Found",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books/999",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"999"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Book not found in your library\"\n}"
+						},
+						{
+							"name": "Delete Book - Unauthorized",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{base_url}}/api/books/1",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"1"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
+						}
+					]
 				}
 			],
 			"description": "Endpoints for managing books in user's library",

--- a/BookMarkd-API.postman_collection.json
+++ b/BookMarkd-API.postman_collection.json
@@ -2068,6 +2068,278 @@
 							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
 						}
 					]
+				},
+				{
+					"name": "Update Book Rating",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"rating\": 4.5\n}"
+						},
+						"url": {
+							"raw": "{{base_url}}/api/books/:book_id/rating",
+							"host": [
+								"{{base_url}}"
+							],
+							"path": [
+								"api",
+								"books",
+								":book_id",
+								"rating"
+							],
+							"variable": [
+								{
+									"key": "book_id",
+									"value": "3",
+									"description": "The ID of the book to rate"
+								}
+							]
+						},
+						"description": "Add or update a rating (0-5) for a completed book. Only works for books with 'read' status (page_progress >= total_pages)."
+					},
+					"response": [
+						{
+							"name": "Update Book Rating Success",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"rating\": 4.5\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/3/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"3",
+										"rating"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"id\": 3,\n  \"title\": \"To Kill a Mockingbird\",\n  \"author\": \"Harper Lee\",\n  \"status\": \"read\",\n  \"open_library_id\": \"OL26965W\",\n  \"page_progress\": 281,\n  \"total_pages\": 281,\n  \"rating\": 4.5\n}"
+						},
+						{
+							"name": "Update Book Rating - Not Read",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"rating\": 4.0\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/2/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"2",
+										"rating"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Can only rate books with 'read' status\"\n}"
+						},
+						{
+							"name": "Update Book Rating - Invalid Range",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"rating\": 6.0\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/3/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"3",
+										"rating"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Rating must be between 0 and 5\"\n}"
+						},
+						{
+							"name": "Update Book Rating - Not Found",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"rating\": 4.5\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/999/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"999",
+										"rating"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Book not found in your library\"\n}"
+						},
+						{
+							"name": "Update Book Rating - Missing Rating",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/3/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"3",
+										"rating"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"error\": \"Rating is required\"\n}"
+						},
+						{
+							"name": "Update Book Rating - Unauthorized",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"rating\": 4.5\n}"
+								},
+								"url": {
+									"raw": "{{base_url}}/api/books/3/rating",
+									"host": [
+										"{{base_url}}"
+									],
+									"path": [
+										"api",
+										"books",
+										"3",
+										"rating"
+									]
+								}
+							},
+							"status": "Unauthorized",
+							"code": 401,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								}
+							],
+							"cookie": [],
+							"body": "{\n  \"msg\": \"Missing Authorization Header\"\n}"
+						}
+					]
 				}
 			],
 			"description": "Endpoints for managing books in user's library",

--- a/OpenLibrary-Covers-API.postman_collection.json
+++ b/OpenLibrary-Covers-API.postman_collection.json
@@ -1,0 +1,441 @@
+{
+	"info": {
+		"_postman_id": "b2c3d4e5-f6g7-8901-bcde-fg2345678901",
+		"name": "OpenLibrary Covers API",
+		"description": "API collection for fetching book cover images from OpenLibrary",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "12345679"
+	},
+	"item": [
+		{
+			"name": "Covers",
+			"item": [
+				{
+					"name": "Get Cover by ID - Small",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/id/{{cover_id}}-S.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"id",
+								"{{cover_id}}-S.jpg"
+							]
+						},
+						"description": "Fetch a small book cover image by OpenLibrary cover ID. Size: Small (S)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by ID - Small Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/id/8739161-S.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"id",
+										"8739161-S.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by ID - Medium",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/id/{{cover_id}}-M.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"id",
+								"{{cover_id}}-M.jpg"
+							]
+						},
+						"description": "Fetch a medium book cover image by OpenLibrary cover ID. Size: Medium (M)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by ID - Medium Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/id/8739161-M.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"id",
+										"8739161-M.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by ID - Large",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/id/{{cover_id}}-L.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"id",
+								"{{cover_id}}-L.jpg"
+							]
+						},
+						"description": "Fetch a large book cover image by OpenLibrary cover ID. Size: Large (L)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by ID - Large Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/id/8739161-L.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"id",
+										"8739161-L.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by ISBN - Medium",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/isbn/{{isbn}}-M.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"isbn",
+								"{{isbn}}-M.jpg"
+							]
+						},
+						"description": "Fetch a book cover image by ISBN number. Size: Medium (M)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by ISBN - Medium Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/isbn/9780140328721-M.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"isbn",
+										"9780140328721-M.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by OCLC - Medium",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/oclc/{{oclc}}-M.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"oclc",
+								"{{oclc}}-M.jpg"
+							]
+						},
+						"description": "Fetch a book cover image by OCLC number. Size: Medium (M)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by OCLC - Medium Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/oclc/28378727-M.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"oclc",
+										"28378727-M.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by LCCN - Medium",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/lccn/{{lccn}}-M.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"lccn",
+								"{{lccn}}-M.jpg"
+							]
+						},
+						"description": "Fetch a book cover image by Library of Congress Control Number. Size: Medium (M)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by LCCN - Medium Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/lccn/93005405-M.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"lccn",
+										"93005405-M.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				},
+				{
+					"name": "Get Cover by OpenLibrary ID - Medium",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "https://covers.openlibrary.org/b/olid/{{olid}}-M.jpg",
+							"protocol": "https",
+							"host": [
+								"covers",
+								"openlibrary",
+								"org"
+							],
+							"path": [
+								"b",
+								"olid",
+								"{{olid}}-M.jpg"
+							]
+						},
+						"description": "Fetch a book cover image by OpenLibrary ID (edition key). Size: Medium (M)"
+					},
+					"response": [
+						{
+							"name": "Get Cover by OpenLibrary ID - Medium Example",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "https://covers.openlibrary.org/b/olid/OL7353617M-M.jpg",
+									"protocol": "https",
+									"host": [
+										"covers",
+										"openlibrary",
+										"org"
+									],
+									"path": [
+										"b",
+										"olid",
+										"OL7353617M-M.jpg"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "raw",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "image/jpeg"
+								}
+							],
+							"cookie": [],
+							"body": ""
+						}
+					]
+				}
+			],
+			"description": "Endpoints for fetching book cover images from OpenLibrary. Supports multiple identifier types (ID, ISBN, OCLC, LCCN, OLID) and three sizes (S=Small, M=Medium, L=Large)."
+		}
+	],
+	"variable": [
+		{
+			"key": "cover_id",
+			"value": "8739161",
+			"type": "string",
+			"description": "OpenLibrary cover ID number"
+		},
+		{
+			"key": "isbn",
+			"value": "9780140328721",
+			"type": "string",
+			"description": "Book ISBN number"
+		},
+		{
+			"key": "oclc",
+			"value": "28378727",
+			"type": "string",
+			"description": "OCLC number"
+		},
+		{
+			"key": "lccn",
+			"value": "93005405",
+			"type": "string",
+			"description": "Library of Congress Control Number"
+		},
+		{
+			"key": "olid",
+			"value": "OL7353617M",
+			"type": "string",
+			"description": "OpenLibrary edition ID"
+		}
+	]
+}

--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -56,7 +56,7 @@ endpoints:
   
   # Books Endpoints
   - name: "Create Book"
-    description: "Add a new book to the authenticated user's library with title, author, page progress, optional OpenLibrary ID, and optional total pages"
+    description: "Add a new book to the authenticated user's library with title, author, and total pages (required). Optional: page_progress (defaults to 0) and open_library_id (used for cover image retrieval)"
     path: "/api/books"
     method: "POST"
   

--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -53,3 +53,14 @@ endpoints:
     description: "Delete a specific goal by ID"
     path: "/api/goals/{goal_id}"
     method: "DELETE"
+  
+  # Books Endpoints
+  - name: "Create Book"
+    description: "Add a new book to the authenticated user's library with title, author, page progress, optional OpenLibrary ID, and optional total pages"
+    path: "/api/books"
+    method: "POST"
+  
+  - name: "Get All Books"
+    description: "Retrieve all books in the authenticated user's library with status (wishlist/reading/read), progress, and ratings"
+    path: "/api/books"
+    method: "GET"

--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -74,3 +74,8 @@ endpoints:
     description: "Update the reading progress (page number) for a book and get updated details with recalculated status"
     path: "/api/books/{book_id}/progress"
     method: "PUT"
+  
+  - name: "Update Book Rating"
+    description: "Add or update a rating (0-5) for a completed book. Only works for books with 'read' status"
+    path: "/api/books/{book_id}/rating"
+    method: "PUT"

--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -64,3 +64,8 @@ endpoints:
     description: "Retrieve all books in the authenticated user's library with status (wishlist/reading/read), progress, and ratings"
     path: "/api/books"
     method: "GET"
+  
+  - name: "Delete Book"
+    description: "Remove a book from the authenticated user's library by book ID"
+    path: "/api/books/{book_id}"
+    method: "DELETE"

--- a/api-docs.yaml
+++ b/api-docs.yaml
@@ -69,3 +69,8 @@ endpoints:
     description: "Remove a book from the authenticated user's library by book ID"
     path: "/api/books/{book_id}"
     method: "DELETE"
+  
+  - name: "Update Book Progress"
+    description: "Update the reading progress (page number) for a book and get updated details with recalculated status"
+    path: "/api/books/{book_id}/progress"
+    method: "PUT"

--- a/backend/app.py
+++ b/backend/app.py
@@ -31,10 +31,12 @@ def create_app(config_name=None):
     from routes.auth import auth_bp
     from routes.health import health_bp
     from routes.goals import goals_bp
+    from routes.books import books_bp
     
     app.register_blueprint(auth_bp, url_prefix='/api/auth')
     app.register_blueprint(health_bp, url_prefix='/api')
     app.register_blueprint(goals_bp, url_prefix='/api')
+    app.register_blueprint(books_bp, url_prefix='/api')
     
     
     # Initialize the Ephemeral DB (create tables + seed)

--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -7,6 +7,7 @@ class Book(db.Model):
     title = db.Column(db.String(200), nullable=False)
     author = db.Column(db.String(120), nullable=False)
     page_count = db.Column(db.Integer)
+    open_library_id = db.Column(db.String(100), unique=True)
     genre = db.Column(db.String(50))
 
     user_books = db.relationship("UserBook", back_populates="book", cascade="all, delete-orphan")

--- a/backend/models/user_book.py
+++ b/backend/models/user_book.py
@@ -9,7 +9,7 @@ class UserBook(db.Model):
     book_id = db.Column(db.Integer, db.ForeignKey("book.book_id"), nullable=False)
     add_date = db.Column(db.Date, default=datetime.today)
     page_progress = db.Column(db.Integer, default=0, nullable=False)
-    user_rating = db.Column(db.Integer, nullable=True)
+    user_rating = db.Column(db.Float, nullable=True)
 
     user = db.relationship("User", back_populates="user_books")
     book = db.relationship("Book", back_populates="user_books")

--- a/backend/models/user_book.py
+++ b/backend/models/user_book.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from extensions import db
 
 class UserBook(db.Model):
@@ -6,8 +7,9 @@ class UserBook(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey("user.user_id"), nullable=False)
     book_id = db.Column(db.Integer, db.ForeignKey("book.book_id"), nullable=False)
-    add_date = db.Column(db.Date)
-    user_rating = db.Column(db.Float)
+    add_date = db.Column(db.Date, default=datetime.today)
+    page_progress = db.Column(db.Integer, default=0, nullable=False)
+    user_rating = db.Column(db.Integer, nullable=True)
 
     user = db.relationship("User", back_populates="user_books")
     book = db.relationship("Book", back_populates="user_books")

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -117,3 +117,34 @@ def create_book():
         "page_progress": user_book.page_progress,
         "total_pages": book.page_count
     }), 201
+
+
+@books_bp.route("/books", methods=["GET"])
+@jwt_required()
+def get_books():
+    """
+    Get all books in the authenticated user's library.
+    
+    Returns: Array of books with title, author, status, open_library_id, page_progress, total_pages, rating
+    """
+    user_id = get_jwt_identity()
+    
+    # Get all user's books with their relationship data
+    user_books = UserBook.query.filter_by(user_id=user_id).all()
+    
+    books_list = []
+    for user_book in user_books:
+        book = user_book.book
+        status = calculate_status(user_book.page_progress, book.page_count)
+        
+        books_list.append({
+            "title": book.title,
+            "author": book.author,
+            "status": status,
+            "open_library_id": book.open_library_id,
+            "page_progress": user_book.page_progress,
+            "total_pages": book.page_count,
+            "rating": user_book.user_rating
+        })
+    
+    return jsonify(books_list), 200

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -66,8 +66,8 @@ def create_book():
     
     try:
         total_pages = int(total_pages)
-        if total_pages < 0:
-            return jsonify({"error": "Total pages must be non-negative"}), 400
+        if total_pages <= 0:
+            return jsonify({"error": "Total pages must be positive"}), 400
     except (ValueError, TypeError):
         return jsonify({"error": "Total pages must be a valid number"}), 400
     

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -71,6 +71,10 @@ def create_book():
     except (ValueError, TypeError):
         return jsonify({"error": "Total pages must be a valid number"}), 400
     
+    # Ensure page_progress does not exceed total_pages
+    if page_progress > total_pages:
+        return jsonify({"error": "Page progress cannot exceed total pages"}), 400
+    
     # Check if book already exists by OpenLibrary ID (if provided)
     book = None
     if open_library_id:

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -31,8 +31,8 @@ def create_book():
     """
     Create a new book for the authenticated user.
     
-    Required params: title, author
-    Optional params: page_progress (default: 0), open_library_id, total_pages
+    Required params: title, author, total_pages
+    Optional params: page_progress (default: 0), open_library_id
     
     Returns: title, author, status, open_library_id, page_progress, total_pages
     """
@@ -53,6 +53,8 @@ def create_book():
         return jsonify({"error": "Title is required"}), 400
     if not author:
         return jsonify({"error": "Author is required"}), 400
+    if not total_pages:
+        return jsonify({"error": "Total pages is required"}), 400
     
     # Validate types
     try:
@@ -62,13 +64,12 @@ def create_book():
     except (ValueError, TypeError):
         return jsonify({"error": "Page progress must be a valid number"}), 400
     
-    if total_pages is not None:
-        try:
-            total_pages = int(total_pages)
-            if total_pages < 0:
-                return jsonify({"error": "Total pages must be non-negative"}), 400
-        except (ValueError, TypeError):
-            return jsonify({"error": "Total pages must be a valid number"}), 400
+    try:
+        total_pages = int(total_pages)
+        if total_pages < 0:
+            return jsonify({"error": "Total pages must be non-negative"}), 400
+    except (ValueError, TypeError):
+        return jsonify({"error": "Total pages must be a valid number"}), 400
     
     # Check if book already exists by OpenLibrary ID (if provided)
     book = None

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -110,6 +110,7 @@ def create_book():
     status = calculate_status(page_progress, total_pages)
     
     return jsonify({
+        "id": book.book_id,
         "title": book.title,
         "author": book.author,
         "status": status,
@@ -138,6 +139,7 @@ def get_books():
         status = calculate_status(user_book.page_progress, book.page_count)
         
         books_list.append({
+            "id": book.book_id,
             "title": book.title,
             "author": book.author,
             "status": status,

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -150,3 +150,30 @@ def get_books():
         })
     
     return jsonify(books_list), 200
+
+
+@books_bp.route("/books/<int:book_id>", methods=["DELETE"])
+@jwt_required()
+def delete_book(book_id):
+    """
+    Delete a book from the authenticated user's library.
+    
+    Params: book_id (in URL)
+    Returns: Success message
+    """
+    user_id = get_jwt_identity()
+    
+    # Find the user's book relationship
+    user_book = UserBook.query.filter_by(
+        user_id=user_id,
+        book_id=book_id
+    ).first()
+    
+    if not user_book:
+        return jsonify({"error": "Book not found in your library"}), 404
+    
+    # Delete the user-book relationship
+    db.session.delete(user_book)
+    db.session.commit()
+    
+    return jsonify({"message": "Book removed from library"}), 200

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -13,16 +13,14 @@ def calculate_status(page_progress, total_pages):
     
     Returns:
         - "wishlist" if page_progress is 0
-        - "reading" if 0 < progress < 100%
-        - "read" if progress is 100%
+        - "reading" if 0 < page_progress < total_pages
+        - "read" if page_progress >= total_pages
     """
     if page_progress == 0:
         return "wishlist"
     
-    if total_pages and total_pages > 0:
-        progress_percent = (page_progress / total_pages) * 100
-        if progress_percent >= 100:
-            return "read"
+    if total_pages and page_progress >= total_pages:
+        return "read"
     
     return "reading"
 

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -31,8 +31,8 @@ def create_book():
     """
     Create a new book for the authenticated user.
     
-    Required params: title, author, page_progress, open_library_id
-    Optional params: total_pages
+    Required params: title, author, page_progress
+    Optional params: open_library_id, total_pages
     
     Returns: title, author, status, open_library_id, page_progress, total_pages
     """
@@ -55,8 +55,6 @@ def create_book():
         return jsonify({"error": "Author is required"}), 400
     if page_progress is None:
         return jsonify({"error": "Page progress is required"}), 400
-    if not open_library_id:
-        return jsonify({"error": "OpenLibrary ID is required"}), 400
     
     # Validate types
     try:
@@ -74,8 +72,10 @@ def create_book():
         except (ValueError, TypeError):
             return jsonify({"error": "Total pages must be a valid number"}), 400
     
-    # Check if book already exists by OpenLibrary ID
-    book = Book.query.filter_by(open_library_id=open_library_id).first()
+    # Check if book already exists by OpenLibrary ID (if provided)
+    book = None
+    if open_library_id:
+        book = Book.query.filter_by(open_library_id=open_library_id).first()
     
     if not book:
         # Create new book

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -31,8 +31,8 @@ def create_book():
     """
     Create a new book for the authenticated user.
     
-    Required params: title, author, page_progress
-    Optional params: open_library_id, total_pages
+    Required params: title, author
+    Optional params: page_progress (default: 0), open_library_id, total_pages
     
     Returns: title, author, status, open_library_id, page_progress, total_pages
     """
@@ -45,7 +45,7 @@ def create_book():
     
     title = data.get("title")
     author = data.get("author")
-    page_progress = data.get("page_progress")
+    page_progress = data.get("page_progress", 0)  # Default to 0
     open_library_id = data.get("open_library_id")
     total_pages = data.get("total_pages")
     
@@ -53,8 +53,6 @@ def create_book():
         return jsonify({"error": "Title is required"}), 400
     if not author:
         return jsonify({"error": "Author is required"}), 400
-    if page_progress is None:
-        return jsonify({"error": "Page progress is required"}), 400
     
     # Validate types
     try:

--- a/backend/routes/books.py
+++ b/backend/routes/books.py
@@ -219,12 +219,16 @@ def update_book_progress(book_id):
     if not user_book:
         return jsonify({"error": "Book not found in your library"}), 404
     
+    # Validate that page_progress does not exceed total pages
+    book = user_book.book
+    if page_progress > book.page_count:
+        return jsonify({"error": "Page progress cannot exceed total pages"}), 400
+    
     # Update progress
     user_book.page_progress = page_progress
     db.session.commit()
     
     # Get book details and calculate status
-    book = user_book.book
     status = calculate_status(user_book.page_progress, book.page_count)
     
     return jsonify({


### PR DESCRIPTION
📣 Important, this has breaking changes to DB schema. Please drop your volume and recreate.

`git pull` - pull latest from main
`docker-compose down -v` - drop your volume
`docker-compose up --build` - rebuild

This pull request adds comprehensive support for managing a user's personal book library, including endpoints and backend logic for adding, viewing, updating, and deleting books, as well as tracking reading progress and ratings. It introduces new models and relationships, updates the API documentation, and integrates the new routes into the application.

**API and Endpoint Enhancements:**

* Added new REST API endpoints for creating, retrieving, updating, and deleting books in a user's library, as well as updating reading progress and ratings, with detailed documentation in `api-docs.yaml`.
* Registered the new `books_bp` blueprint in the Flask application to enable all book-related routes.

**Backend and Model Changes:**

* Implemented the `books.py` route handler with logic for:
  - Adding a book (with OpenLibrary ID support and duplicate checks)
  - Retrieving all books with status, progress, and ratings
  - Deleting a book from a user's library
  - Updating reading progress and recalculating status
  - Rating a book (only when marked as 'read')
* Updated the `Book` model to include an optional, unique `open_library_id` field for better integration with external sources.
* Enhanced the `UserBook` model to track `page_progress` (with default 0), allow nullable ratings, and set a default `add_date` using `datetime.today`.

<img width="1704" height="957" alt="image" src="https://github.com/user-attachments/assets/96458e0d-ec5d-4fd7-954a-c031e6b30e45" />