### PR TITLE
Add search by ISBN

### DIFF
--- a/frontend/src/components/BookList.tsx
+++ b/frontend/src/components/BookList.tsx
@@ -167,7 +167,7 @@ export const BookList = forwardRef(function BookList(_props, ref) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-2 mb-2">
                       <div className="flex-1 min-w-0">
-                        <h3 className="text-gray-900 truncate">{book.title}</h3>
+                        <h3 className="text-gray-900">{book.title}</h3>
                         <p className="text-gray-600 text-sm truncate">{book.author}</p>
                       </div>
                       <DropdownMenu>


### PR DESCRIPTION
This PR adds search ability by ISBN, as was suggested in class. This is frankly less desirable, surprisingly, than searching by author and/or title. In my testing, most searches by ISBN return no cover and no page information, though we still get title and author. 